### PR TITLE
Documentation setup - install statinamic as dependencies

### DIFF
--- a/demo/content/docs/setup.md
+++ b/demo/content/docs/setup.md
@@ -6,7 +6,7 @@ title: How to setup statinamic
 
 ```console
 $ npm install
-$ npm install --save-dev statinamic
+$ npm install --save statinamic
 ```
 
 Statinamic require some boilerplate, in order to provide you some flexibility.


### PR DESCRIPTION
If I follow your instructions  here http://moox.io/statinamic/docs/setup/#install-from-npm

You recommand to install `statinamic` as a `devDependencies`. If I follow this, all `dependencies` are added as `devDependencies `in my package.json. 

After that, I have to run the following: `statinamic setup`  But this time all `dependencies` are copy as `dependencies`, so I have this kind of error each time I run `npm install`:

```console
npm WARN package.json Dependency 'postcss-loader' exists in both dependencies and devDependencies, using 'postcss-loader@^0.7.0' from dependencies
```
So I think it's better to provide in your instruction to install `statinamic` as `dependencies`

