### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ docs/scripts/statinamic-static.js
 
 # some tests output some files
 src/md-collection-loader/__tests__/output/
+
+# Default file on Mac
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ src/md-collection-loader/__tests__/output/
 
 # Default file on Mac
 .DS_Store
+
+# npm error file
+npm-debug.log


### PR DESCRIPTION
`.DS_Store` is a [useless file to have in a .git repo](https://en.wikipedia.org/wiki/.DS_Store) but every Mac will add it to the folders.

I added it to the `.gitignore` so nobody gets another persons `.DS_Store`.

EDIT: Added the npm error file, `npm-debug.log` to the `.gitignore` as well.