### PR TITLE
Bundle collection to html by default

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -6,6 +6,10 @@ import { Provider } from "react-redux"
 
 import fetchJSON from "../fetchJSON"
 import MetadataProvider from "../MetadataProvider"
+import {
+  set as collectionSet,
+  error as collectionError,
+} from "../redux/modules/collection"
 
 export default function statinamic({
   metadata,
@@ -18,18 +22,17 @@ export default function statinamic({
     devtools = <DevToolsComponent store={ store } />
   }
 
-  const baseUrl = __BASE_URL__
-  fetchJSON(`${ baseUrl.pathname }collection.json`)
-    .then(
-      ({ data }) => store.dispatch({
-        type: "COLLECTION_SET",
-        collection: data,
-      }),
-      (error) => store.dispatch({
-        type: "COLLECTION_ERROR",
-        error,
-      })
-    )
+  // Don't fetch collection
+  // when it is already bundled in HTML
+  const collection = store.getState().collection
+  if (collection.length === 0) {
+    const baseUrl = __BASE_URL__
+    fetchJSON(`${ baseUrl.pathname }collection.json`)
+      .then(
+        ({ data }) => store.dispatch(collectionSet(data)),
+        (error) => store.dispatch(collectionError(error))
+      )
+  }
 
   ReactDOM.render(
     <div id="statinamic-container">
@@ -42,5 +45,4 @@ export default function statinamic({
     </div>,
     document.getElementById("statinamic")
   )
-
 }

--- a/src/redux/modules/collection.js
+++ b/src/redux/modules/collection.js
@@ -1,19 +1,34 @@
+export const COLLECTION_GET = "COLLECTION_GET"
+export const COLLECTION_SET = "COLLECTION_SET"
+export const COLLECTION_FORGET = "COLLECTION_FORGET"
+export const COLLECTION_ERROR = "COLLECTION_ERROR"
+
 export default function reducer(state = [], action) {
 
   switch (action.type) {
-  case "COLLECTION_GET":
+  case COLLECTION_GET:
     return []
 
-  case "COLLECTION_SET":
+  case COLLECTION_SET:
     return action.collection
 
-  case "COLLECTION_FORGET":
+  case COLLECTION_FORGET:
     return []
 
-  case "COLLECTION_ERROR":
+  case COLLECTION_ERROR:
     return []
 
   default:
     return state
   }
 }
+
+export const set = (data) => ({
+  type: COLLECTION_SET,
+  collection: data,
+})
+
+export const error = (error) => ({
+  type: COLLECTION_ERROR,
+  error,
+})

--- a/src/static/to-html/__tests__/index.js
+++ b/src/static/to-html/__tests__/index.js
@@ -44,7 +44,6 @@ test("writeAllHTMLFiles", (t) => {
       t.is(uri, "test-url")
     },
     writeHTMLFile: (basename, html) => {
-      console.info(beautifyHTML(html))
       const expectedHTML = (
       `<!doctype html>
 <html lang="en">

--- a/src/static/to-html/__tests__/index.js
+++ b/src/static/to-html/__tests__/index.js
@@ -44,6 +44,7 @@ test("writeAllHTMLFiles", (t) => {
       t.is(uri, "test-url")
     },
     writeHTMLFile: (basename, html) => {
+      console.info(beautifyHTML(html))
       const expectedHTML = (
       `<!doctype html>
 <html lang="en">
@@ -61,7 +62,14 @@ test("writeAllHTMLFiles", (t) => {
   </div>
   <script>
     window.__INITIAL_STATE__ = {
-      "pages": {}
+      "pages": {},
+      "collection": {
+        "": {
+          "head": {
+            "foo": "bar"
+          }
+        }
+      }
     }
   </script>
   <script src="/statinamic-client.js"></script>

--- a/src/static/to-html/__tests__/url-as-html.js
+++ b/src/static/to-html/__tests__/url-as-html.js
@@ -40,6 +40,13 @@ test("url as html", async (t) => {
         "": {
           "home": "page"
         }
+      },
+      "collection": {
+        "": {
+          "head": {
+            "foo": "bar"
+          }
+        }
       }
     }
   </script>

--- a/src/static/to-html/__tests__/utils/index.js
+++ b/src/static/to-html/__tests__/utils/index.js
@@ -14,6 +14,13 @@ export const testStore = createStore(
         home: "page",
       },
     },
+    "collection": {
+      "": {
+        head: {
+          foo: "bar",
+        },
+      },
+    },
   }
 )
 

--- a/src/static/to-html/url-as-html.js
+++ b/src/static/to-html/url-as-html.js
@@ -60,20 +60,6 @@ export default (url, { metadata, routes, store, baseUrl }, testing) => {
               headTags.link
             )
 
-            let collection = store.getState().collection
-            const pageData = store.getState().pages[url]
-
-            if (pageData.hasOwnProperty('head')) {
-              const pageHead = pageData.head
-
-              if (
-                pageHead.hasOwnProperty('collection') &&
-                !pageHead.collection
-              ) {
-                collection = undefined
-              }
-            }
-
             const initialState = {
               ...store.getState(),
 
@@ -81,7 +67,6 @@ export default (url, { metadata, routes, store, baseUrl }, testing) => {
               pages: {
                 [url]: store.getState().pages[url],
               },
-              collection,
               // skip some data \\
               // already in bundle
               layouts: undefined,

--- a/src/static/to-html/url-as-html.js
+++ b/src/static/to-html/url-as-html.js
@@ -60,6 +60,20 @@ export default (url, { metadata, routes, store, baseUrl }, testing) => {
               headTags.link
             )
 
+            let collection = store.getState().collection
+            const pageData = store.getState().pages[url]
+
+            if (pageData.hasOwnProperty('head')) {
+              const pageHead = pageData.head
+
+              if (
+                pageHead.hasOwnProperty('collection') &&
+                !pageHead.collection
+              ) {
+                collection = undefined
+              }
+            }
+
             const initialState = {
               ...store.getState(),
 
@@ -67,14 +81,12 @@ export default (url, { metadata, routes, store, baseUrl }, testing) => {
               pages: {
                 [url]: store.getState().pages[url],
               },
-
+              collection,
               // skip some data \\
-              // ensure collection is not in all pages output
-              // async json file is prefered (file length concerns)
-              collection: undefined,
               // already in bundle
               layouts: undefined,
             }
+
             script = `window.__INITIAL_STATE__ = ${
               escapeJSONforHTML(JSON.stringify(initialState))
             }`


### PR DESCRIPTION
Continue from #98 
ref #92 #96 

This PR will bundle collection to html by  default.

We can disable this behavior on page specific by passing an option `collection: false` to it's head

Example:
```
---
layout: Post
title: Some page you don't want to bundle collection by default
collection: false
---
```

TODO:

- [x] Add collection to bundle
- [x] Don't fetch collection when it is already in store
- [x] Allow to disable this behaviour
- [ ] Fix tests