### PR TITLE
Hot loading for markdown files

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -15,6 +15,7 @@
     "babel-preset-react": "^6.3.13",
     "babel-preset-react-hmre": "^1.0.1",
     "babel-preset-stage-1": "^6.3.13",
+    "bundle-loader": "^0.5.4",
     "classnames": "^2.2.3",
     "css-loader": "^0.17.0",
     "eslint": "^1.7.2",

--- a/docs/scripts/build.js
+++ b/docs/scripts/build.js
@@ -21,7 +21,7 @@ const webpackConfig = {
     filename: "[name].js",
     publicPath: config.baseUrl.path,
   },
-
+  devtool: "eval",
   resolve: {
     extensions: [
       // node default extensions
@@ -37,6 +37,8 @@ const webpackConfig = {
   resolveLoader: {
     root: [ path.join(config.cwd, "node_modules") ],
   },
+
+  target: "web",
 
   module: {
     // ! \\ note that loaders are executed from bottom to top !
@@ -190,7 +192,7 @@ builder({
     output: {
       ...webpackConfig.output,
       libraryTarget: "commonjs2",
-      path: __dirname,
+      path: path.join(__dirname, "..", config.destination, "build"),
     },
 
     plugins: [
@@ -199,7 +201,7 @@ builder({
       // extract (and overwrite) statinamic client css
       // poor workaround to avoid having 2 identical files...
       new ExtractTextPlugin(
-        path.join("..", config.destination, "statinamic-client.css")
+        path.join(__dirname, "..", config.destination, "statinamic-client.css")
       ),
     ],
   },

--- a/docs/scripts/index-client.js
+++ b/docs/scripts/index-client.js
@@ -1,8 +1,3 @@
-// all md files as JSON + generate collections
-require.context("../content", true, /\.md$/)
-
-// ---
-
 import "whatwg-fetch"
 import statinamicClient from "statinamic/lib/client"
 

--- a/docs/scripts/load-async.js
+++ b/docs/scripts/load-async.js
@@ -1,0 +1,29 @@
+import enhanceCollection from "statinamic/lib/enhance-collection"
+
+const getFileFromContext = (context, filename) => {
+  const bundledResult = context.keys().map(context)
+  const result = enhanceCollection(bundledResult, {
+    filter: { __filename: filename },
+    limit: 1,
+  })
+
+  return result[0]
+}
+
+export default function loadAsync(filename, callback) {
+  if (__PROD__) {
+    const bundledResult = require("bundle!../content/" + filename)
+    bundledResult(result => callback(result))
+  }
+  else if (__DEV__) {
+    let context = require.context("../content", true, /\.md$/)
+    callback(getFileFromContext(context, filename))
+
+    if (module.hot) {
+      module.hot.accept(context.id, function() {
+        context = require.context("../content", true, /\.md$/)
+        callback(getFileFromContext(context, filename))
+      })
+    }
+  }
+}

--- a/docs/scripts/load-async.js
+++ b/docs/scripts/load-async.js
@@ -1,14 +1,4 @@
-import enhanceCollection from "statinamic/lib/enhance-collection"
-
-const getFileFromContext = (context, filename) => {
-  const bundledResult = context.keys().map(context)
-  const result = enhanceCollection(bundledResult, {
-    filter: { __filename: filename },
-    limit: 1,
-  })
-
-  return result[0]
-}
+import fileFromContext from "statinamic/lib/file-from-context"
 
 export default function loadAsync(filename, callback) {
   if (__PROD__) {
@@ -17,12 +7,12 @@ export default function loadAsync(filename, callback) {
   }
   else if (__DEV__) {
     let context = require.context("../content", true, /\.md$/)
-    callback(getFileFromContext(context, filename))
+    callback(fileFromContext(context, filename))
 
     if (module.hot) {
       module.hot.accept(context.id, function() {
         context = require.context("../content", true, /\.md$/)
-        callback(getFileFromContext(context, filename))
+        callback(fileFromContext(context, filename))
       })
     }
   }

--- a/docs/web_modules/app/store.js
+++ b/docs/web_modules/app/store.js
@@ -2,7 +2,7 @@ import { combineReducers } from "redux"
 import createStore from "statinamic/lib/redux/createStore"
 import * as statinamicReducers from "statinamic/lib/redux/modules"
 import minifyCollection from "statinamic/lib/md-collection-loader/minify"
-
+import getPage from "../../scripts/load-async"
 import * as layouts from "layouts"
 
 const store = createStore(
@@ -19,6 +19,12 @@ const store = createStore(
     },
 
     layouts,
+    pages: {
+      ...(typeof window !== "undefined") &&
+      (typeof window.__INITIAL_STATE__ !== "undefined") &&
+      window.__INITIAL_STATE__.pages,
+      getPage,
+    },
   }
 )
 

--- a/src/PageContainer/component.js
+++ b/src/PageContainer/component.js
@@ -1,5 +1,5 @@
-import React, { Component } from "react"
-import { PropTypes } from "react"
+import React, { Component, PropTypes } from "react"
+import enhanceCollection from "../enhance-collection"
 
 function splatToUri(string) {
   return string.replace(/\/index\.html$/, "")
@@ -47,7 +47,20 @@ export default class PageContainer extends Component {
     }
     const page = props.pages[pageKey]
     if (!page) {
-      props.getPage(pageKey)
+      if (props.collection.length !== 0) {
+        // Handle index.md ==> /statinamic//
+        let pageObject = props.collection.map(page => ({
+          ...page,
+          __url: page.__url.replace("//", "/"),
+        }))
+        pageObject = enhanceCollection(pageObject, {
+          filter: { __url: "/" + props.params.splat + "/" },
+        })
+
+        props.getPage(pageObject[0].__filename, (result) => {
+          props.setPage(pageKey, result)
+        })
+      }
     }
     else {
       if (page.error) {
@@ -72,7 +85,6 @@ export default class PageContainer extends Component {
 
   render() {
     const pageKey = splatToUri(this.props.params.splat)
-
     const page = this.props.pages[pageKey]
 
     if (!page) {

--- a/src/PageContainer/index.js
+++ b/src/PageContainer/index.js
@@ -4,12 +4,15 @@ import * as pageActions from "../redux/modules/pages"
 import PageContainer from "./component"
 
 export default connect(
-  ({ pages, layouts }) => {
-    return { pages, layouts }
-  },
+  ({ collection, pages, layouts }) => ({
+    collection,
+    getPage: pages.getPage,
+    pages,
+    layouts,
+  }),
   (dispatch) => {
     return {
-      getPage: (page) => dispatch(pageActions.get(page)),
+      setPage: (...args) => dispatch(pageActions.set(...args)),
     }
-  },
+  }
 )(PageContainer)

--- a/src/file-from-context/index.js
+++ b/src/file-from-context/index.js
@@ -1,0 +1,16 @@
+/**
+ * Get file data from require.context
+ * @param  {func} context  [require.context]
+ * @param  {string} filename [relative with content folder]
+ * @return {object}          [parsed markdown file or json]
+ */
+const fileFromContext = (context, filename) => {
+  const result = context
+    .keys()
+    .map(context)
+    .filter(x => x.__filename === filename)
+
+  return result[0]
+}
+
+export default fileFromContext

--- a/src/md-collection-loader/index.js
+++ b/src/md-collection-loader/index.js
@@ -129,5 +129,5 @@ module.exports = function(input) {
     }, 100)
   }
 
-  return "module.exports = __webpack_public_path__ + " + JSON.stringify(jsonUrl)
+  return "module.exports = " + JSON.stringify(mdObject)
 }

--- a/src/redux/modules/pages.js
+++ b/src/redux/modules/pages.js
@@ -8,7 +8,11 @@ export const FORGET = "statinamic/pages/FORGET"
 export const ERROR = "statinamic/pages/ERROR"
 
 // redux reducer
-export default function reducer(state = {}, action) {
+const initialState = {
+  getPage: () => {},
+}
+
+export default function reducer(state = initialState, action) {
 
   switch (action.type) {
   case GET:
@@ -63,5 +67,15 @@ export function get(page) {
     ],
     page,
     promise: fetchJSON(path.join("/", page, "index.json")),
+  }
+}
+
+export function set(page, data) {
+  return {
+    type: SET,
+    page,
+    response: {
+      data,
+    },
   }
 }


### PR DESCRIPTION
![out](https://cloud.githubusercontent.com/assets/3049054/12601289/8eb195b0-c4d2-11e5-821f-1bc1c894252d.gif)


This time, I took a different approach.

In dev, just bundle everything into a big file using `require.context` and enable module.hot with it
In prod, use webpack bundle-loader.

TODO: 

- [ ] Move getPage(loadAsync) function some where not redux store (context ? )
- [x] Remove lodash
- [ ] Remove all debug code added
- [ ] Remove index.json file (handle these LOC https://github.com/MoOx/statinamic/blob/master/src/builder/index.js#L64-L70)
- [ ] Remove fetch 
- [ ] Figure out how to handle error case on chunk loading
- [ ] Move build folder somewhere (or just delete it after build)