### PR TITLE
Don't include assets config by default

### DIFF
--- a/src/configurator/index.js
+++ b/src/configurator/index.js
@@ -12,7 +12,7 @@ export default function config(pkg = {}, argv = process.argv) {
     cwd: process.cwd(),
     source: "content",
     destination: "dist",
-    assets: "assets",
+    assets: undefined,
     CNAME: false,
     nojekyll: true,
     devHost: "0.0.0.0",


### PR DESCRIPTION
If there is no `content/assets` fs-extra will throw an error about no file/directory