### PR TITLE
[WIP] Read assets file name (js, css) from webpack stats instead of hardcoded name

### DIFF
--- a/docs/scripts/webpack.config.babel.js
+++ b/docs/scripts/webpack.config.babel.js
@@ -87,7 +87,7 @@ export default {
   ),
 
   plugins: [
-    new ExtractTextPlugin("[name].css", { disable: config.dev }),
+    new ExtractTextPlugin("[name]_[hash].css", { disable: config.dev }),
     new webpack.DefinePlugin({ "process.env": {
       NODE_ENV: JSON.stringify(
         config.production ? "production" : process.env.NODE_ENV

--- a/docs/scripts/webpack.config.client.js
+++ b/docs/scripts/webpack.config.client.js
@@ -45,7 +45,7 @@ export default {
   output: {
     ...webpackConfig.output,
     libraryTarget: "var",
-    filename: "[name].js",
+    filename: "[name]_[hash].js",
   },
   entry: {
     "statinamic-client": path.join(__dirname, "index-client"),

--- a/src/builder/index.js
+++ b/src/builder/index.js
@@ -38,11 +38,23 @@ export default function(options) {
       // There is probably a better way to get markdown as json without reading
       // fs, but I am tired
       const pagesData = {}
+      const assetsFiles = {
+        css: [],
+        js: [],
+      }
       const assets = stats.compilation.assets
       Object.keys(assets).forEach((name) => {
         if (name.endsWith("index.json")) {
           const url = filenameToUrl(name)
           pagesData[url] = JSON.parse(assets[name]._value)
+        }
+
+        if (name.endsWith(".js")) {
+          assetsFiles.js.push(name)
+        }
+
+        if (name.endsWith(".css")) {
+          assetsFiles.css.push(name)
         }
       })
 
@@ -53,6 +65,7 @@ export default function(options) {
           ...getMdUrlsFromWebpackStats(stats, config.source),
         ],
         pagesData,
+        assetsFiles,
         layouts,
         metadata,
         routes,

--- a/src/builder/server.js
+++ b/src/builder/server.js
@@ -60,6 +60,10 @@ export default (webpackConfig, options = {}) => {
           {}
         ),
     },
+    output: {
+      ...webpackConfig.output,
+      filename: "[name].js",
+    },
     plugins: [
       ...(webpackConfig.plugins || []),
       ...(options.plugins || []),
@@ -79,6 +83,7 @@ export default (webpackConfig, options = {}) => {
 
   // webpack requirements
   const webpackCompiler = webpack(devConfig)
+
   server.use(webpackDevMiddleware(webpackCompiler, {
     publicPath: webpackConfig.output.publicPath,
     noInfo: !config.verbose,
@@ -147,7 +152,10 @@ export default (webpackConfig, options = {}) => {
         store: options.store,
 
         baseUrl: config.baseUrl,
-        css: !config.dev,
+        assetsFiles: {
+          js: ["statinamic-client.js"],
+          css: !config.dev,
+        },
       })
       .then(
         (html) => {

--- a/src/html-metas/__tests__/index.js
+++ b/src/html-metas/__tests__/index.js
@@ -13,7 +13,10 @@ test("html default metas", (t) => {
 
 test("html static metas", (t) => {
   t.same(
-    htmlMetas({ baseUrl: url.parse("http://domain.ext/"), css: true }),
+    htmlMetas({
+      baseUrl: url.parse("http://domain.ext/"),
+      css: [ "statinamic-client.css" ],
+    }),
     [
       ...defaultMetas,
       `<link rel="stylesheet" href="/statinamic-client.css" />`,
@@ -23,7 +26,10 @@ test("html static metas", (t) => {
 
 test("html static metas with path", (t) => {
   t.same(
-    htmlMetas({ baseUrl: url.parse("http://domain.ext/basep/"), css: true }),
+    htmlMetas({
+      baseUrl: url.parse("http://domain.ext/basep/"),
+      css: [ "statinamic-client.css" ],
+    }),
     [
       ...defaultMetas,
       `<link rel="stylesheet" href="/basep/statinamic-client.css" />`,

--- a/src/html-metas/index.js
+++ b/src/html-metas/index.js
@@ -7,10 +7,12 @@ export const defaultMetas = [
 export default ({ baseUrl, css } = {}) => {
   const metas = [ ...defaultMetas ]
 
-  if (css) {
-    metas.push(
-      `<link rel="stylesheet" href="${ baseUrl.path }statinamic-client.css" />`
-    )
+  if (css && Array.isArray(css)) {
+    css.forEach(fileName => {
+      metas.push(
+        `<link rel="stylesheet" href="${ baseUrl.path }${ fileName }" />`
+      )
+    })
   }
 
   return metas

--- a/src/static/to-html/__tests__/index.js
+++ b/src/static/to-html/__tests__/index.js
@@ -35,6 +35,10 @@ test("writeAllHTMLFiles", (t) => {
       "test-url",
     ],
     pagesData: {},
+    assetsFiles: {
+      js: [ "statinamic-client.js" ],
+      css: [ "statinamic-client.css" ],
+    },
     store: testStore,
     routes: testRoutes,
     destination: "destination",
@@ -50,7 +54,9 @@ test("writeAllHTMLFiles", (t) => {
 <html lang="en">
 
 <head>
-  ${ htmlMetas({ baseUrl: { path: "/" }, css: true }).join("\n  ") }
+  ${ htmlMetas({
+    baseUrl: { path: "/" },
+    css: [ "statinamic-client.css" ] }).join("\n  ") }
   <title data-react-helmet="true"></title>
 </head>
 

--- a/src/static/to-html/__tests__/url-as-html.js
+++ b/src/static/to-html/__tests__/url-as-html.js
@@ -14,6 +14,9 @@ const fixture = {
   routes: testRoutes,
   store: testStore,
   baseUrl: url.parse("http://0.0.0.0:3000/"),
+  assetsFiles: {
+    js: [ "statinamic-client.js" ],
+  },
 }
 
 test("url as html", async (t) => {

--- a/src/static/to-html/index.js
+++ b/src/static/to-html/index.js
@@ -62,6 +62,7 @@ export function writeAllHTMLFiles({
   baseUrl,
   destination,
   pagesData,
+  assetsFiles,
 
   layouts,
   metadata,
@@ -87,7 +88,7 @@ export function writeAllHTMLFiles({
           store,
 
           baseUrl,
-          css: true,
+          assetsFiles,
         }, testing)
         .then((html) => writeHTMLFile(basename, html))
         .then(() => forgetPageData(url, store))
@@ -98,6 +99,7 @@ export function writeAllHTMLFiles({
 
 export default ({
   pagesData,
+  assetsFiles,
   urls,
 
   baseUrl,
@@ -113,6 +115,7 @@ export default ({
     baseUrl,
     destination,
     pagesData,
+    assetsFiles,
 
     layouts,
     metadata,

--- a/src/static/to-html/url-as-html.js
+++ b/src/static/to-html/url-as-html.js
@@ -20,7 +20,7 @@ export default (url, {
   store,
 
   baseUrl,
-  css,
+  assetsFiles,
 }, testing) => {
   const render = ReactDOMserver[
     !testing
@@ -28,7 +28,11 @@ export default (url, {
     : "renderToStaticMarkup"
   ]
   return new Promise((resolve, reject) => {
-    const defaultMetas = htmlMetas({ baseUrl, css }).join("")
+    const defaultMetas = htmlMetas({
+      baseUrl,
+      css: assetsFiles.css,
+    }).join("")
+
     try {
       match(
         {
@@ -69,6 +73,7 @@ export default (url, {
             )
 
             const headTags = Helmet.rewind()
+
             head = (
               defaultMetas +
               headTags.meta +
@@ -100,7 +105,12 @@ export default (url, {
             )
             // body = ...
           }
-
+          let scriptTags = false
+          if (assetsFiles.js && Array.isArray(assetsFiles.js)) {
+            scriptTags = assetsFiles.js.map(fileName =>
+              <script src={ `${ baseUrl.path }${ fileName }` }></script>
+            )
+          }
           // write htmlString as html files
           return resolve(
             // render html document as simple html
@@ -110,10 +120,7 @@ export default (url, {
                 head,
                 body,
                 script,
-                children: (
-                  <script src={ `${ baseUrl.path }statinamic-client.js` }>
-                  </script>
-                ),
+                children: scriptTags,
               })
             )
           )

--- a/src/static/to-html/url-as-html.js
+++ b/src/static/to-html/url-as-html.js
@@ -108,7 +108,10 @@ export default (url, {
           let scriptTags = false
           if (assetsFiles.js && Array.isArray(assetsFiles.js)) {
             scriptTags = assetsFiles.js.map(fileName =>
-              <script src={ `${ baseUrl.path }${ fileName }` }></script>
+              <script
+                key={ filename }
+                src={ `${ baseUrl.path }${ fileName }` }
+              ></script>
             )
           }
           // write htmlString as html files

--- a/src/static/to-html/url-as-html.js
+++ b/src/static/to-html/url-as-html.js
@@ -109,7 +109,7 @@ export default (url, {
           if (assetsFiles.js && Array.isArray(assetsFiles.js)) {
             scriptTags = assetsFiles.js.map(fileName =>
               <script
-                key={ filename }
+                key={ fileName }
                 src={ `${ baseUrl.path }${ fileName }` }
               ></script>
             )


### PR DESCRIPTION
This would allow user to use a real CDN for long-term caching.

There is 1 issue those, I had to hardcoded file name in dev mode 

https://github.com/MoOx/statinamic/pull/125/files#diff-9ec6170964a6a4d01ea02104c51b3d84R65

Looking for a way to read it from wepackCompiler