### PR TITLE
Allow no assets config

### DIFF
--- a/src/builder/index.js
+++ b/src/builder/index.js
@@ -26,7 +26,7 @@ export default function(options) {
 
   if (config.static) {
     // Copy static assets to build folder
-    if (config.assets !== undefined) {
+    if (config.assets) {
       const copyDest = path.join(destination, config.assets.route)
       fs.copySync(config.assets.path, copyDest)
       log(color.green("✓ Static assets: copy static assets completed"))

--- a/src/builder/server.js
+++ b/src/builder/server.js
@@ -102,7 +102,7 @@ export default (webpackConfig, options = {}) => {
   router.get("*", express.static(webpackConfig.output.path))
 
   // user static assets
-  if (config.assets !== undefined) {
+  if (config.assets) {
     server.use(
       config.baseUrl.pathname + config.assets.route,
       express.static(config.assets.path)

--- a/src/configurator/index.js
+++ b/src/configurator/index.js
@@ -103,7 +103,7 @@ export default function config(pkg = {}, argv = process.argv) {
   config.baseUrl = { ... url.parse(url.format(config.baseUrl)) }
 
   // Prepare config.assets path and route
-  if (config.assets !== undefined) {
+  if (config.assets) {
 
     // normalize simple string options
     if (typeof config.assets === "string") {


### PR DESCRIPTION
Since `undefined` is invalid in json and we have a default assets config. So `config.assets !== undefined` always true