### PR TITLE
Changing nodejs_version order on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,8 @@
 
 environment:
   matrix:
-    - nodejs_version: '4'
     - nodejs_version: '5'
+    - nodejs_version: '4'
 
 version: "{build}"
 build: off


### PR DESCRIPTION
Since npm@3 is a lot faster then npm@2. Testing node 5 first should give us faster respond about failing in window