### PR TITLE
Show a warning for invalid assets folder

### DIFF
--- a/src/configurator/__tests__/content/assets/.gitkeep
+++ b/src/configurator/__tests__/content/assets/.gitkeep
@@ -1,0 +1,1 @@
+fixture for assets test

--- a/src/configurator/index.js
+++ b/src/configurator/index.js
@@ -1,6 +1,6 @@
 import url from "url"
 import { join } from "path"
-
+import fs from "fs"
 import minimist from "minimist"
 
 const defaultOptions = {
@@ -155,8 +155,21 @@ export default function config(pkg = {}, argv = process.argv) {
         route: config.assets.route,
       }
 
-      // TODO test folder
-      // https://github.com/MoOx/statinamic/issues/121
+      // Test folder
+      try {
+        const stats = fs.lstatSync(config.assets.path)
+        if (!stats.isDirectory()) {
+          // Just throw a dump error
+          throw new Error("This is not a folder")
+        }
+      }
+      catch (e) {
+        errors.push(
+          config.assets.path +
+          " doesn't exist or isn't a folder. " +
+          "Please check your assets config"
+        )
+      }
     }
   }
 


### PR DESCRIPTION
Close https://github.com/MoOx/statinamic/issues/121

~~I also change `throw new Error` to `console.error`. We are providing pretty straight forward error messages. no need for stack trace~~ . Never mind. It broke tests