### PR TITLE
Allow to start static server serving build dist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   ([#104](https://github.com/MoOx/statinamic/pull/104))
 - Fixed: ability to pass custom webpack devServer config
   ([#157](https://github.com/MoOx/statinamic/issues/157))
+- Added: cli option to server static dist build `npm run build -- --server`
+  ([#163](https://github.com/MoOx/statinamic/pull/163))
 - Added: during development for pre-rendering, dev server will refresh
   all files for each render
   ([#145](https://github.com/MoOx/statinamic/pull/145))

--- a/src/builder/index.js
+++ b/src/builder/index.js
@@ -62,6 +62,17 @@ export default function(options) {
         exports,
         store,
       })
+      .then(() => {
+        if (config.server) {
+          devServer(null, { config })
+        }
+      })
+      .catch((error) => {
+        log(color.red("✗ Faild to start static server"))
+        setTimeout(() => {
+          throw error
+        }, 1)
+      })
     })
   }
   else if (config.server) {

--- a/src/builder/server.js
+++ b/src/builder/server.js
@@ -31,151 +31,162 @@ export default (webpackConfig, options = {}) => {
     )
   }
 
-  const devEntries = [
-    require.resolve(`webpack-hot-middleware/client`),
-  ]
-
-  const devConfig = {
-    ...webpackConfig,
-    // debug: true,
-    // watch: true,
-    // colors: true,
-    entry: {
-      // add devEntries
-      ...Object.keys(webpackConfig.entry)
-        .reduce(
-          (acc, key) => {
-            // some entries do not need extra stuff
-            acc[key] = key.match(options.noDevEntriesTest) !== null
-              ? webpackConfig.entry[key]
-              : [
-                ...devEntries,
-                ...Array.isArray(webpackConfig.entry[key])
-                  ? webpackConfig.entry[key]
-                  : [ webpackConfig.entry[key] ],
-              ]
-            return acc
-          },
-          {}
-        ),
-    },
-    plugins: [
-      ...(webpackConfig.plugins || []),
-      ...(options.plugins || []),
-      new webpack.optimize.OccurenceOrderPlugin(),
-      new webpack.HotModuleReplacementPlugin(),
-      new webpack.NoErrorsPlugin(),
-      new WebpackErrorNotificationPlugin(),
-    ],
-    eslint: {
-      ...webpackConfig.eslint,
-      emitWarning: true,
-    },
-  }
-
   const server = express()
 
-  // webpack requirements
-  const webpackCompiler = webpack(devConfig)
-
-  server.use(webpackDevMiddleware(webpackCompiler, {
-    publicPath: webpackConfig.output.publicPath,
-    noInfo: !config.verbose,
-    ...devConfig.devServer,
-  }))
-
-  let entries = []
-  webpackCompiler.plugin("done", function(stats) {
-    // reset entries
-    entries = []
-    const namedChunks = stats.compilation.namedChunks
-    Object.keys(namedChunks).forEach((chunkName) => {
-      entries = [
-        ...entries,
-        ...namedChunks[chunkName].files.filter(
-          (file) => !file.endsWith(".hot-update.js")
-        ),
-      ]
-    })
-  })
-
-  // routing for the part we want (starting to the baseUrl pathname)
-  const router = Router()
-  server.use(config.baseUrl.pathname, router)
-
-  // fallback to index for unknow pages?
-  router.use(historyFallbackMiddleware())
-
-  // webpack static ressources
-  router.get("*", express.static(webpackConfig.output.path))
-
-  // user static assets
-  if (config.assets) {
+  if (config.static && config.server) {
     server.use(
-      config.baseUrl.pathname + config.assets.route,
-      express.static(config.assets.path)
+      config.baseUrl.pathname,
+      express.static(join(config.cwd, config.destination))
     )
   }
+  else {
+    const devEntries = [
+      require.resolve(`webpack-hot-middleware/client`),
+    ]
 
-  // prerender pages when possible
-  const memoryFs = webpackCompiler.outputFileSystem
-  router.get("*", (req, res, next) => {
-    const item = getItemOrContinue(collection, req, res, next)
-    if (item) {
-      const relativeUri = item.__dataUrl.replace(config.baseUrl.pathname, "")
-      const filepath = join(config.cwd, config.destination, relativeUri)
-      const fileContent = memoryFs.readFileSync(filepath)
-      const data = JSON.parse(fileContent.toString())
-      options.store.dispatch({
-        type: pagesActions.SET,
-        page: req.originalUrl,
-        response: {
-          data,
-        },
-      })
-
-      if (!firstRun) {
-        cleanNodeCache(config.cwd)
-      }
-      firstRun = false
-
-      urlAsHtml(req.originalUrl, {
-        exports: options.exports,
-        store: options.store,
-        collection,
-        baseUrl: config.baseUrl,
-        assetsFiles: {
-          js: entries,
-          css: !config.dev,
-        },
-      })
-      .then(
-        (html) => {
-          res.setHeader("Content-Type", "text/html")
-          res.end(html)
-        }
-      )
-      .catch((err) => {
-        log(err)
-        res.setHeader("Content-Type", "text/plain")
-        res.end(err.toString())
-      })
+    const devConfig = {
+      ...webpackConfig,
+      // debug: true,
+      // watch: true,
+      // colors: true,
+      entry: {
+        // add devEntries
+        ...Object.keys(webpackConfig.entry)
+          .reduce(
+            (acc, key) => {
+              // some entries do not need extra stuff
+              acc[key] = key.match(options.noDevEntriesTest) !== null
+                ? webpackConfig.entry[key]
+                : [
+                  ...devEntries,
+                  ...Array.isArray(webpackConfig.entry[key])
+                    ? webpackConfig.entry[key]
+                    : [ webpackConfig.entry[key] ],
+                ]
+              return acc
+            },
+            {}
+          ),
+      },
+      plugins: [
+        ...(webpackConfig.plugins || []),
+        ...(options.plugins || []),
+        new webpack.optimize.OccurenceOrderPlugin(),
+        new webpack.HotModuleReplacementPlugin(),
+        new webpack.NoErrorsPlugin(),
+        new WebpackErrorNotificationPlugin(),
+      ],
+      eslint: {
+        ...webpackConfig.eslint,
+        emitWarning: true,
+      },
     }
-  })
 
-  // HMR
-  server.use(webpackHotMiddleware(webpackCompiler))
+    // webpack requirements
+    const webpackCompiler = webpack(devConfig)
+
+    server.use(webpackDevMiddleware(webpackCompiler, {
+      publicPath: webpackConfig.output.publicPath,
+      noInfo: !config.verbose,
+      ...devConfig.devServer,
+    }))
+
+    let entries = []
+    webpackCompiler.plugin("done", function(stats) {
+      // reset entries
+      entries = []
+      const namedChunks = stats.compilation.namedChunks
+      Object.keys(namedChunks).forEach((chunkName) => {
+        entries = [
+          ...entries,
+          ...namedChunks[chunkName].files.filter(
+            (file) => !file.endsWith(".hot-update.js")
+          ),
+        ]
+      })
+    })
+
+    // routing for the part we want (starting to the baseUrl pathname)
+    const router = Router()
+    server.use(config.baseUrl.pathname, router)
+
+    // fallback to index for unknow pages?
+    router.use(historyFallbackMiddleware())
+
+    // webpack static ressources
+    router.get("*", express.static(webpackConfig.output.path))
+
+    // user static assets
+    if (config.assets) {
+      server.use(
+        config.baseUrl.pathname + config.assets.route,
+        express.static(config.assets.path)
+      )
+    }
+
+    // prerender pages when possible
+    const memoryFs = webpackCompiler.outputFileSystem
+    router.get("*", (req, res, next) => {
+      const item = getItemOrContinue(collection, req, res, next)
+      if (item) {
+        const relativeUri = item.__dataUrl.replace(config.baseUrl.pathname, "")
+        const filepath = join(config.cwd, config.destination, relativeUri)
+        const fileContent = memoryFs.readFileSync(filepath)
+        const data = JSON.parse(fileContent.toString())
+        options.store.dispatch({
+          type: pagesActions.SET,
+          page: req.originalUrl,
+          response: {
+            data,
+          },
+        })
+
+        if (!firstRun) {
+          cleanNodeCache(config.cwd)
+        }
+        firstRun = false
+
+        urlAsHtml(req.originalUrl, {
+          exports: options.exports,
+          store: options.store,
+          collection,
+          baseUrl: config.baseUrl,
+          assetsFiles: {
+            js: entries,
+            css: !config.dev,
+          },
+        })
+        .then(
+          (html) => {
+            res.setHeader("Content-Type", "text/html")
+            res.end(html)
+          }
+        )
+        .catch((err) => {
+          log(err)
+          res.setHeader("Content-Type", "text/plain")
+          res.end(err.toString())
+        })
+      }
+    })
+
+    // HMR
+    server.use(webpackHotMiddleware(webpackCompiler))
+  }
 
   // THAT'S IT
-  server.listen(config.baseUrl.port, config.baseUrl.hostname, (err) => {
+  const { devHost, devPort } = config
+
+  server.listen(devPort, devHost, (err) => {
     if (err) {
       log(err)
 
       return
     }
-    log(`Dev server started on ${ config.baseUrl.href }`)
+    const href = `http://${ devHost }:${ devPort }${ config.baseUrl.pathname }`
+    log(`Dev server started on ${ href }`)
     if (config.open) {
-      opn(`${ config.baseUrl.href }`)
+      opn(href)
     }
   })
 }


### PR DESCRIPTION
I often use python simpleHTTPServer to server static build dist. But as `statinamic docs` is not in domain's root, I had to do something hacky like this

```shell
npm run build && \
mv dist statinamic && \
mkdir dist && \
mv statinamic dist/ && \
start-server
```

With this PR, I can simply doing this `npm run build -- --server`

or better, add a npm script like `npm run build:server`