### PR TITLE
Redux devtools cause invalid checksum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
   This values should be strings.
   See changes in ``boilerplate/scripts/build.js``.
   ([#145](https://github.com/MoOx/statinamic/pull/145))
+- Fixed: Redux devtools cause invalid checksum
+  ([#152](https://github.com/MoOx/statinamic/issues/152))
 - Fixed: Homepage url is not prerendered as ``//`` if you don't have a pathname
   in your base url (``package.json/homepage``).
   ([#104](https://github.com/MoOx/statinamic/pull/104))

--- a/src/client/DevTools.js
+++ b/src/client/DevTools.js
@@ -1,9 +1,9 @@
-import React from "react"
+import React, { Component, PropTypes } from "react"
 import { createDevTools } from "redux-devtools"
 import LogMonitor from "redux-devtools-log-monitor"
 import DockMonitor from "redux-devtools-dock-monitor"
 
-export default createDevTools(
+const DevTools = createDevTools(
   <DockMonitor
     toggleVisibilityKey="ctrl-h"
     changePositionKey="ctrl-q"
@@ -11,3 +11,30 @@ export default createDevTools(
     <LogMonitor theme="twilight" />
   </DockMonitor>
 )
+
+export default DevTools
+
+export class DevToolsComponent extends Component {
+  static propTypes = {
+    store: PropTypes.object,
+  };
+
+  constructor(props) {
+    super(props)
+    this.isComponentMounted = false
+  }
+
+  componentDidMount() {
+    this.isComponentMounted = true
+    this.forceUpdate()
+  }
+
+  render() {
+    if (!this.isComponentMounted) {
+      return null
+    }
+    return (
+      <DevTools store={ this.props.store } />
+    )
+  }
+}

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -14,7 +14,7 @@ export default function statinamic({
 }) {
   let devtools = false
   if (process.env.REDUX_DEVTOOLS && process.env.CLIENT) {
-    const DevToolsComponent = require("./DevTools.js").default
+    const DevToolsComponent = require("./DevTools.js").DevToolsComponent
     devtools = <DevToolsComponent store={ store } />
   }
 

--- a/src/static/to-html/url-as-html.js
+++ b/src/static/to-html/url-as-html.js
@@ -80,6 +80,7 @@ export default (url, {
                     <RouterContextProvider { ...renderProps } />
                   </ReduxContextProvider>
                 </StatinamicContextProvider>
+                { process.env.REDUX_DEVTOOLS && <noscript /> }
               </div>
             )
 


### PR DESCRIPTION
Rendering devtools is useless and make `url-to-html` logic more complicated. Instead I choose this approach. Devtools won't be render until component is mounted

Close #152 