### PR TITLE
Fixed: Avoid warning of babel-plugin-webpack-loader in boilerplate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- Fixed: Avoid warning of babel-plugin-webpack-loader in boilerplate
+  ([#185](https://github.com/MoOx/statinamic/issues/185))
+
 # 0.8.0 - 2016-02-24
 
 → [Example of update from 0.7 to 0.8](https://github.com/thangngoc89/blog/pull/58/files)

--- a/src/bin/data/template.js
+++ b/src/bin/data/template.js
@@ -7,7 +7,7 @@ const template = {
     "lint:js": "eslint --fix .",
     "lint:css": "stylelint \"web_modules/**/*.css\"",
     "lint": "npm run lint:js && npm run lint:css",
-    "statinamic": "cross-env BABEL_ENV=statinamic DEBUG=statinamic:* babel-node scripts/build",
+    "statinamic": "cross-env BABEL_DISABLE_CACHE=1 BABEL_ENV=statinamic DEBUG=statinamic:* babel-node scripts/build",
     "start": "npm run statinamic -- --server --open --dev",
     "build": "npm run statinamic -- --static --production",
     "pretest": "npm run lint",


### PR DESCRIPTION
Close #185