### PR TITLE
Don't split webpack error and warning to mutiltple lines

### DIFF
--- a/src/builder/webpack.js
+++ b/src/builder/webpack.js
@@ -9,23 +9,14 @@ export default (webpackConfig, log, cb) => {
 
     if (stats.hasErrors()) {
       stats.compilation.errors.forEach(
-        item => {
-          // log(...[
-          //   color.red("Error:"),
-          //   ...item.message.split("\n"),
-          // ])
-          item.stack.split("\n").forEach(line => log(color.red(line)))
-        }
+        item => log(color.red(item.stack || item))
       )
-
       throw new Error("webpack build failed with errors")
     }
+
     if (stats.hasWarnings()) {
       stats.compilation.warnings.forEach(
-        item => log(...[
-          color.yellow("Warning:"),
-          ...item.message.split("\n"),
-        ])
+        item => log(color.yellow("Warning: %s", item.message))
       )
     }
 


### PR DESCRIPTION
``debug`` will do it for us.

This is bad right ?

![image](https://cloud.githubusercontent.com/assets/3049054/13315131/8a4b0bd0-dbdb-11e5-988e-69c0704cc8a6.png)
