### PR TITLE
Fixed: 404 page overide webpack hmr route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Fixed: 404 page overide webpack hmr route
+
 # 0.8.1 - 2016-02-25
 
 - Fixed: URLs which does not have the required trailing slash are now adjusted.

--- a/src/builder/server.js
+++ b/src/builder/server.js
@@ -92,6 +92,9 @@ export default (webpackConfig, options = {}) => {
       ...devConfig.devServer,
     }))
 
+    // HMR
+    server.use(webpackHotMiddleware(webpackCompiler))
+
     let entries = []
     webpackCompiler.plugin("done", function(stats) {
       // reset entries
@@ -186,9 +189,6 @@ export default (webpackConfig, options = {}) => {
         res.end(err.toString())
       })
     })
-
-    // HMR
-    server.use(webpackHotMiddleware(webpackCompiler))
   }
 
   // THAT'S IT


### PR DESCRIPTION
Router has catch all route * so webpack hmr route is never reached. 

Why put it above static assets route ? See #103

Ref: https://github.com/glenjamin/webpack-hot-middleware/issues/26#issuecomment-144941322
