### PR TITLE
Refactor md-collection-loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+- Changed: Refactor md-collection-loader
+  - Pluggable markdown parser (can be ascii parser or something else)
+  - Move loader query to webpack option (avoid json.stringify)
+
+  See ([#217](https://github.com/MoOx/statinamic/pull/217)) for more information
+
 # 0.8.2 - 2016-02-27
 
 - Fixed: 404 page overide webpack hmr route

--- a/boilerplate/scripts/webpack.config.babel.js
+++ b/boilerplate/scripts/webpack.config.babel.js
@@ -13,32 +13,12 @@ export default {
     loaders: [
       { // statinamic requirement
         test: /\.md$/,
-        loader: "statinamic/lib/md-collection-loader" +
-          `?${ JSON.stringify({
-            context: path.join(config.cwd, config.source),
-            feedsOptions: {
-              title: pkg.name,
-              site_url: pkg.homepage,
-            },
-            feeds: {
-              "feed.xml": {
-                collectionOptions: {
-                  filter: { layout: "Post" },
-                  sort: "date",
-                  reverse: true,
-                  limit: 20,
-                },
-              },
-            },
-          }) }`,
+        loader: "statinamic/lib/md-collection-loader" ,
       },
       {
         test: /\.css$/,
         loader: ExtractTextPlugin.extract(
           "style-loader",
-        // loader:
-        //   "style-loader" +
-        //   "!" +
           "css-loader" +
             "?modules"+
             "&localIdentName=[path][name]--[local]--[hash:base64:5]" +
@@ -62,31 +42,49 @@ export default {
     ],
   },
 
+  statinamic: {
+    context: path.join(config.cwd, config.source),
+    mdParser: (string) => (
+      require("markdown-it")({
+        html: true,
+        linkify: true,
+        typographer: true,
+        highlight: (code, lang) => {
+          code = code.trim()
+          const hljs = require("highlight.js")
+          // language is recognized by highlight.js
+          if (lang && hljs.getLanguage(lang)) {
+            return hljs.highlight(lang, code).value
+          }
+          // ...or fallback to auto
+          return hljs.highlightAuto(code).value
+        },
+      })
+      .use(require("markdown-it-toc-and-anchor"), { tocFirstLevel: 2 })
+      .render(string)
+    ),
+    feedsOptions: {
+      title: pkg.name,
+      site_url: pkg.homepage,
+    },
+    feeds: {
+      "feed.xml": {
+        collectionOptions: {
+          filter: { layout: "Post" },
+          sort: "date",
+          reverse: true,
+          limit: 20,
+        },
+      },
+    },
+  },
+
   postcss: () => [
     require("stylelint")(),
     require("postcss-cssnext")({ browsers: "last 2 versions" }),
     require("postcss-browser-reporter")(),
     require("postcss-reporter")(),
   ],
-
-  markdownIt: (
-    require("markdown-it")({
-      html: true,
-      linkify: true,
-      typographer: true,
-      highlight: (code, lang) => {
-        code = code.trim()
-        const hljs = require("highlight.js")
-        // language is recognized by highlight.js
-        if (lang && hljs.getLanguage(lang)) {
-          return hljs.highlight(lang, code).value
-        }
-        // ...or fallback to auto
-        return hljs.highlightAuto(code).value
-      },
-    })
-      .use(require("markdown-it-toc-and-anchor"), { tocFirstLevel: 2 })
-  ),
 
   plugins: [
     new ExtractTextPlugin("[name].[hash].css", { disable: config.dev }),

--- a/docs/scripts/webpack.config.babel.js
+++ b/docs/scripts/webpack.config.babel.js
@@ -13,32 +13,12 @@ export default {
     loaders: [
       { // statinamic requirement
         test: /\.md$/,
-        loader: "statinamic/lib/md-collection-loader" +
-          `?${ JSON.stringify({
-            context: path.join(config.cwd, config.source),
-            feedsOptions: {
-              title: pkg.name,
-              site_url: pkg.homepage,
-            },
-            feeds: {
-              "feed.xml": {
-                collectionOptions: {
-                  filter: { layout: "Post" },
-                  sort: "date",
-                  reverse: true,
-                  limit: 20,
-                },
-              },
-            },
-          }) }`,
+        loader: "statinamic/lib/md-collection-loader",
       },
       {
         test: /\.css$/,
         loader: ExtractTextPlugin.extract(
           "style-loader",
-        // loader:
-        //   "style-loader" +
-        //   "!" +
           "css-loader" +
             "?modules"+
             "&localIdentName=[path][name]--[local]--[hash:base64:5]" +
@@ -62,31 +42,49 @@ export default {
     ],
   },
 
+  statinamic: {
+    context: path.join(config.cwd, config.source),
+    mdParser: (string) => (
+      require("markdown-it")({
+        html: true,
+        linkify: true,
+        typographer: true,
+        highlight: (code, lang) => {
+          code = code.trim()
+          const hljs = require("highlight.js")
+          // language is recognized by highlight.js
+          if (lang && hljs.getLanguage(lang)) {
+            return hljs.highlight(lang, code).value
+          }
+          // ...or fallback to auto
+          return hljs.highlightAuto(code).value
+        },
+      })
+      .use(require("markdown-it-toc-and-anchor"), { tocFirstLevel: 2 })
+      .render(string)
+    ),
+    feedsOptions: {
+      title: pkg.name,
+      site_url: pkg.homepage,
+    },
+    feeds: {
+      "feed.xml": {
+        collectionOptions: {
+          filter: { layout: "Post" },
+          sort: "date",
+          reverse: true,
+          limit: 20,
+        },
+      },
+    },
+  },
+
   postcss: () => [
     require("stylelint")(),
     require("postcss-cssnext")({ browsers: "last 2 versions" }),
     require("postcss-browser-reporter")(),
     require("postcss-reporter")(),
   ],
-
-  markdownIt: (
-    require("markdown-it")({
-      html: true,
-      linkify: true,
-      typographer: true,
-      highlight: (code, lang) => {
-        code = code.trim()
-        const hljs = require("highlight.js")
-        // language is recognized by highlight.js
-        if (lang && hljs.getLanguage(lang)) {
-          return hljs.highlight(lang, code).value
-        }
-        // ...or fallback to auto
-        return hljs.highlightAuto(code).value
-      },
-    })
-      .use(require("markdown-it-toc-and-anchor"), { tocFirstLevel: 2 })
-  ),
 
   plugins: [
     new ExtractTextPlugin("[name].[hash].css", { disable: config.dev }),

--- a/src/md-collection-loader/index.js
+++ b/src/md-collection-loader/index.js
@@ -26,7 +26,7 @@ return a object:
  */
 import path from "path"
 import loaderUtils from "loader-utils"
-import yamlHeaderParser from "gray-matter"
+import fontMatterParser from "gray-matter"
 import markdownIt from "markdown-it"
 
 import joinUri from "../_utils/join-uri"
@@ -40,17 +40,15 @@ let timeout
 
 module.exports = function(input) {
 
-  const query = loaderUtils.parseQuery(this.query)
+  const query = this.options.statinamic || {}
   const context = query.context || this.options.context
 
-  const mdIt = query.markdownIt
-    ? query.markdownIt
-    : this.options.markdownIt
-      ? this.options.markdownIt
-      : markdownIt()
+  const mdParser = query.mdParser
+    ? query.mdParser
+    : (string) => markdownIt().render(string)
 
   const defaultHead = query.defaultHead
-  const parsed = yamlHeaderParser(input)
+  const parsed = fontMatterParser(input)
 
   const relativePath = path.relative(context, this.resourcePath)
   const tmpUrl = urlify(
@@ -78,7 +76,7 @@ module.exports = function(input) {
       ...defaultHead,
       ...parsed.data,
     },
-    body: mdIt.render(parsed.content),
+    body: mdParser(parsed.content),
     rawBody: parsed.content,
     raw: parsed.orig,
     ...metadata,


### PR DESCRIPTION
- Pluggable markdown parser (can be ascii parser or something else)
- Move loader query to webpack option (avoid json.stringify)

Close #209

@ben-eb you can use remark now

---
Update:

statinamic requires `mdParser` field : 

```js
(string) => parsedHtml
```