### PR TITLE
Use npm install instead of symlink to avoid webpack version conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "test": "npm run tests && npm run docs && npm run test-boilerplate",
     "test-with-coverage": "nyc --all --require babel-core/register npm run tests && npm run docs && npm run test-boilerplate",
     "pretest-boilerplate": "rimraf test-boilerplate && npm run babelify && rimraf boilerplate/node_modules && rimraf boilerplate/package.json",
-    "test-boilerplate": "mkdirp test-boilerplate/node_modules && cd test-boilerplate && npm init -y && lnfs ../ node_modules/statinamic && node ./node_modules/statinamic/lib/bin/statinamic-setup -t && npm install && npm run build",
+    "test-boilerplate": "mkdirp test-boilerplate && cd test-boilerplate && npm init -y && npm install ../ && node ./node_modules/.bin/statinamic setup -t && npm install && npm run build",
     "coverage": "nyc report --reporter=lcovonly && codecov",
     "release": "npmpub"
   },


### PR DESCRIPTION
Close #236 

poke @MoOx 