### PR TITLE
Fix PageError

### DIFF
--- a/docs/web_modules/layouts/PageError/index.js
+++ b/docs/web_modules/layouts/PageError/index.js
@@ -6,7 +6,7 @@ import styles from "./index.css"
 export default class PageError extends Component {
 
   static propTypes = {
-    error: PropTypes.number,
+    error: PropTypes.oneOfType([ PropTypes.number, PropTypes.string ]),
     errorText: PropTypes.string,
   };
 

--- a/src/redux/modules/pages.js
+++ b/src/redux/modules/pages.js
@@ -52,9 +52,10 @@ export default function reducer(state = {}, action) {
         : {
           error: "Unexpected Error",
           errorText: (
-            action.response.message ||
-            (action.response.error && action.response.error.message) ||
-            "Seriously, this is weird."
+            (action.response)
+            ? action.response.message ||
+              (action.response.error && action.response.error.message)
+            : "Seriously, this is weird."
           ),
         }
       ),


### PR DESCRIPTION
- `action.response === undefined` when request a 404 page.

- Fix propTypes in PageError layout