### PR TITLE
Fix: Use localhost as default devHost on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
     (that's why ``config`` must expose your webpack configurations)
   - You webpack configuration can now skip some tiny weird part specific to
     statinamic.
+- Changed: Use localhost as default address to open new browser tab (for Windows
+  compatibility since Windows doesn't resolve 0.0.0.0 as localhost/127.0.0.1)
 - Changed: **``md-collection-loader`` has been renamed to ``content-loader``.**
 - Changed: ``content-loader`` now use [remark](https://github.com/wooorm/remark)
   as the default markdown engine.

--- a/src/builder/server.js
+++ b/src/builder/server.js
@@ -205,7 +205,7 @@ export default (options = {}) => {
     const href = `http://${ devHost }:${ devPort }${ config.baseUrl.pathname }`
     log(`Dev server started on ${ href }`)
     if (config.open) {
-      opn(href)
+      opn(href.replace(devHost, "localhost"))
     }
   })
 }


### PR DESCRIPTION
Close #257 

Waiting for appveyor (don't have access to a windows machine atm)