### PR TITLE
Update dependencies

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -53,11 +53,16 @@
     "react-router": "^2.0.0",
     "react-svg-inline": "^1.1.0",
     "redux": "^3.0.0",
+    "remark": "^4.1.1",
+    "remark-autolink-headings": "^3.0.0",
+    "remark-highlight.js": "^3.0.0",
+    "remark-html": "^3.0.0",
+    "remark-slug": "^4.1.0",
     "style-loader": "^0.12.3",
     "stylelint": "^5.0.1",
     "stylelint-config-standard": "^4.0.1",
     "webpack": "^1.12.1",
-    "whatwg-fetch": "^0.9.0"
+    "whatwg-fetch": "^0.11.0"
   },
   "babel": {
     "presets": [

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "remark": "^4.1.1",
     "rimraf": "^2.4.2",
     "rss": "^1.2.0",
+    "simple-json-fetch": "^1.0.1",
     "strip-markdown": "^0.3.1",
     "underscore.string": "^3.2.3",
     "valid-url": "^1.0.9",
@@ -93,7 +94,6 @@
     "react": "^15.0.0-rc.1",
     "react-addons-test-utils": "^15.0.0-rc.1",
     "react-dom": "^15.0.0-rc.1",
-    "react-element-to-jsx-string": "^2.4.0",
     "react-helmet": "^2.1.0",
     "react-redux": "^4.0.0",
     "react-router": "^2.0.0",
@@ -103,7 +103,6 @@
     "remark-highlight.js": "^3.0.0",
     "remark-html": "^3.0.0",
     "remark-slug": "^4.1.0",
-    "simple-json-fetch": "^1.0.1",
     "sinon": "^1.17.3",
     "stylelint": "^5.0.1",
     "stylelint-config-standard": "^4.0.1"
@@ -125,9 +124,10 @@
     "react-router": "^2.0.0",
     "redux": "^3.0.0",
     "webpack": "^1.12.1",
-    "whatwg-fetch": "^0.9.0"
+    "whatwg-fetch": "^0.11.0"
   },
   "optionalPeerDependencies": {
+    "babel-eslint": "^6.0.0-beta.0",
     "babel-preset-stage-1": "^6.3.13",
     "css-loader": "^0.17.0",
     "eslint": "^2.0.0",
@@ -136,7 +136,6 @@
     "eslint-plugin-react": "^4.0.0",
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.8.1",
-    "highlight.js": "^8.5.0",
     "json-loader": "^0.5.2",
     "postcss-browser-reporter": "^0.4.0",
     "postcss-cssnext": "^2.4.0",
@@ -144,6 +143,11 @@
     "postcss-reporter": "^1.3.0",
     "raw-loader": "^0.5.1",
     "react-svg-inline": "^1.1.0",
+    "remark": "^4.1.1",
+    "remark-autolink-headings": "^3.0.0",
+    "remark-highlight.js": "^3.0.0",
+    "remark-html": "^3.0.0",
+    "remark-slug": "^4.1.0",
     "style-loader": "^0.12.3",
     "stylelint": "^5.0.1",
     "stylelint-config-standard": "^4.0.1"


### PR DESCRIPTION
- Move simple-json-fetch to dep (missing when install from boilerplate)
- Allow peerDep whatwg-fetch >= 0.9.0 (React is using 0.11.0, no reason to use older one)
- Remove react-jsx-.... (not needed anymore)
- Added missing babel-eslint to opPeerDeps
- Move remark* from devDep to opPeerDeps
- Remove hightlight.js from opPeerDeps (became a dep of remark-highlight.js)