### PR TITLE
Use node-portfinder to avoid error when port is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- Added: Use node-portfinder to avoid error when port is used
+  ([#320](https://github.com/MoOx/statinamic/issues/320))
+
 # 0.9.3 - 2016-04-04
 
 ## Boilerplate

--- a/__tests__/cli.js
+++ b/__tests__/cli.js
@@ -4,6 +4,7 @@ import { join } from "path"
 import { exec } from "child_process"
 
 const target = join(__dirname, "..", "test-boilerplate")
+// const execOpts = { cwd: target, stdio: "inherit" }
 const execOpts = { cwd: target }
 
 const statinamic = "node ./node_modules/.bin/statinamic"
@@ -47,9 +48,41 @@ test.cb("should NOT throw if a CLI flag is recognized", (t) => {
     }
   )
 
+  // ...or be ok quickly
+  // (so we assume it's ok and kill the process, we don't need the actual build)
   const timeout = setTimeout(() => {
     child.kill()
     t.pass()
     t.end()
   }, 500)
+})
+
+test.cb("should NOT throw if port is used", (t) => {
+  const app = require("express")()
+
+  const server = app.listen(5432, (err) => {
+    if (err) {
+      t.fail()
+      t.end()
+    }
+
+    const child = exec(
+      `${ statinamic } start --devPort=5432`, execOpts,
+
+      (err) => {
+        if (err) {
+          clearTimeout(timeout)
+          t.fail()
+          t.end()
+        }
+      }
+    )
+
+    const timeout = setTimeout(() => {
+      child.kill()
+      server.close()
+      t.pass()
+      t.end()
+    }, 2000)
+  })
 })

--- a/__tests__/cli.js
+++ b/__tests__/cli.js
@@ -4,7 +4,6 @@ import { join } from "path"
 import { exec } from "child_process"
 
 const target = join(__dirname, "..", "test-boilerplate")
-// const execOpts = { cwd: target, stdio: "inherit" }
 const execOpts = { cwd: target }
 
 const statinamic = "node ./node_modules/.bin/statinamic"
@@ -60,17 +59,18 @@ test.cb("should NOT throw if a CLI flag is recognized", (t) => {
 test.cb("should NOT throw if port is used", (t) => {
   const app = require("express")()
 
-  const server = app.listen(5432, (err) => {
+  const server = app.listen(8081, (err) => {
     if (err) {
       t.fail()
       t.end()
     }
 
     const child = exec(
-      `${ statinamic } start --devPort=5432`, execOpts,
+      `${ statinamic } start --devPort=8081`, execOpts,
 
       (err) => {
         if (err) {
+          console.log(err)
           clearTimeout(timeout)
           t.fail()
           t.end()

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "lru-memoize": "^1.0.0",
     "mkdirp": "^0.5.1",
     "opn": "^3.0.2",
+    "portfinder": "^1.0.2",
     "redbox-react": "^1.2.2",
     "remark": "^4.1.1",
     "remark-autolink-headings": "^3.0.0",

--- a/src/builder/server.js
+++ b/src/builder/server.js
@@ -7,6 +7,7 @@ import WebpackErrorNotificationPlugin from "webpack-error-notification"
 
 import opn from "opn"
 import debug from "debug"
+import portFinder from "portfinder"
 
 import collection from "../content-loader/cache.js"
 import urlAsHtml from "../static/to-html/url-as-html"
@@ -196,17 +197,26 @@ export default (options = {}) => {
   // THAT'S IT
   const { devHost, devPort } = config
 
-  server.listen(devPort, devHost, (err) => {
-    if (err) {
-      log(err)
+  portFinder.basePort = devPort
 
-      return
+  portFinder.getPort((err, port) => {
+    if (err) {
+      throw err
     }
-    const href = `http://${ devHost }:${ devPort }${ config.baseUrl.pathname }`
-    log(`Dev server started on ${ href }`)
-    if (config.open) {
-      opn(href.replace(devHost, "localhost"))
+
+    if (port !== devHost) {
+      log(`Port ${ devPort } is not available. Using port ${ port } instead.`)
     }
+    server.listen(port, devHost, (err) => {
+      if (err) {
+        throw err
+      }
+      const href = `http://${ devHost }:${ port }${ config.baseUrl.pathname }`
+      log(`Dev server started on ${ href }`)
+      if (config.open) {
+        opn(href.replace(devHost, "localhost"))
+      }
+    })
   })
 }
 


### PR DESCRIPTION
Close #320