### PR TITLE
Fix: Remove unused define env vars in webpack config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Boilerplate
+
+- Removed: Remove unused define environment variables in webpack client config
+  ([#315](https://github.com/MoOx/statinamic/pull/351))
+
 # 0.9.2 - 2016-03-22
 
 - Fixed: Missing babel-register package.

--- a/boilerplate/scripts/webpack.config.babel.js
+++ b/boilerplate/scripts/webpack.config.babel.js
@@ -68,8 +68,6 @@ export default ({ config, pkg }) => ({
       NODE_ENV: JSON.stringify(
         config.production ? "production" : process.env.NODE_ENV
       ),
-      CLIENT: true,
-      REDUX_DEVTOOLS: Boolean(process.env.REDUX_DEVTOOLS),
       STATINAMIC_PATHNAME: JSON.stringify(process.env.STATINAMIC_PATHNAME),
     } }),
     ...config.production && [


### PR DESCRIPTION
This should be released as a hotfix.