### PR TITLE
AVA serial script to run test in serial on node 4 - Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 
 node_js:
   - '5'
+  - '4'
 
 # fail asap when there is a failure
 matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@
 environment:
   matrix:
     - nodejs_version: '5'
+    - nodejs_version: '4'
 
 version: "{build}"
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,7 @@ cache:
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm set progress=false
+  - npm install -g npm@latest
   - npm prune
   - npm install
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,6 @@
 environment:
   matrix:
     - nodejs_version: '5'
-    - nodejs_version: '4'
 
 version: "{build}"
 build: off
@@ -19,7 +18,6 @@ cache:
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm set progress=false
-  - npm install -g npm@latest
   - npm prune
   - npm install
 

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "lint:css": "stylelint \"**/web_modules/**/*.css\"",
     "lint": "npm run lint:js && npm run lint:css",
     "pretests": "npm run lint",
-    "tests": "ava",
+    "tests": "babel-node scripts/ava-serial.js",
     "integration-tests": "ava __tests__/*.js",
     "pretest-boilerplate": "npm run transpile",
     "test-boilerplate": "babel-node scripts/test-boilerplate.js",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,8 @@
     "redux": "^3.0.0",
     "sinon": "^1.17.3",
     "stylelint": "^5.0.1",
-    "stylelint-config-standard": "^4.0.1"
+    "stylelint-config-standard": "^4.0.1",
+    "throat": "^2.0.2"
   },
   "peerDependencies": {
     "babel-cli": "^6.3.17",

--- a/scripts/ava-serial.js
+++ b/scripts/ava-serial.js
@@ -1,0 +1,60 @@
+// Stolen from https://git.io/vajFu @ben-eb
+import { spawn } from "child_process"
+import pkg from "../package.json"
+import globby from "globby"
+
+const throttlePromise = (myArray, iterator, limit) => {
+  const pickUpNextTask = () => {
+    if (myArray.length) {
+      return iterator(myArray.shift())
+    }
+  }
+  const startChain = () => (
+    Promise.resolve().then(function next() {
+      return pickUpNextTask().then(next)
+    })
+  )
+
+  const chains = []
+  for (let k = 0; k < limit; k += 1) {
+    chains.push(startChain())
+  }
+  Promise.all(chains)
+}
+
+const spawnAva = (file) => (
+  new Promise((resolve, reject) => {
+    // Normalize string to array
+    const filesToTest = (Array.isArray(file)) ? file : [ file ]
+
+    const ps = spawn(
+      process.execPath,
+      [ "node_modules/.bin/ava", ...filesToTest ],
+      {
+        stdio: "inherit",
+      }
+    )
+
+    ps.on("close", (code) => {
+      if (code === 0) {
+        return resolve(code)
+      }
+      return reject(code)
+    })
+  })
+)
+
+const pattern = pkg.ava.files
+
+if (process.env.TRAVIS && /v4/.test(process.version)) {
+  globby(pattern)
+  .then((tests) => {
+    throttlePromise(tests, spawnAva, 2)
+  })
+  .catch((err) => {
+    throw err
+  })
+}
+else {
+  spawnAva(pattern)
+}


### PR DESCRIPTION
Close #344

What is the different between this custom script and AVA `--serial` flag ? 

-> This script run each test files in serial while `--serial` flag run tests in each file in serial.

---

# Benchmark

Must be worse on Travis

```
$ time babel-node scripts/ava-serial.js
real	0m23.612s
user	1m5.740s
sys	0m4.192s

$ time ava
real	0m16.832s
user	0m56.544s
sys	0m3.840s
```

