### PR TITLE
chore: Bump css-loader to ^0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@
 - Fixed: ``PageError`` warning about missing PropTypes
   ([#357](https://github.com/MoOx/statinamic/issues/357)).
 
+- Changed: Bump css-loader to ^0.23.0. This may improve performance a little bit
+  ([#374](https://github.com/MoOx/statinamic/issues/374))
+
 - Changed: ``PageError`` is nicer and now looks like documentation 404.
 
 - Added: a ``PageLoading`` component is now provided and include 2 indicators:

--- a/docs/package.json
+++ b/docs/package.json
@@ -29,7 +29,7 @@
     "babel-preset-react-hmre": "^1.0.1",
     "babel-preset-stage-1": "^6.3.13",
     "classnames": "^2.2.3",
-    "css-loader": "^0.17.0",
+    "css-loader": "^0.23.0",
     "eslint": "^2.0.0",
     "eslint-config-i-am-meticulous": "^3.0.0",
     "eslint-loader": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
   "optionalPeerDependencies": {
     "babel-eslint": "^6.0.0-beta.0",
     "babel-preset-stage-1": "^6.3.13",
-    "css-loader": "^0.17.0",
+    "css-loader": "^0.23.0",
     "eslint": "^2.0.0",
     "eslint-config-i-am-meticulous": "^3.0.0",
     "eslint-loader": "^1.3.0",


### PR DESCRIPTION
This reduces docs' build time 8 seconds

# Before:

```console
$ time npm run build

> Statinamic@ build /home/khoa/web/statinamic/docs
> statinamic build

  statinamic:builder ✓ Static assets: copy static assets completed +0ms
  statinamic:builder ✓ Static assets: client build completed +18s
  statinamic:static ✓ Static html files: 19 files written. +42s
  statinamic:static ✓ .nojekyll created. +21ms
  statinamic:static ✓ manifest.appcache created. +27ms
  statinamic:static ✓ Build successful. +0ms

real	1m5.683s
user	1m8.752s
sys	0m3.244s
```

# After 

```console
$ time npm run build

> Statinamic@ build /home/khoa/web/statinamic/docs
> statinamic build

  statinamic:builder ✓ Static assets: copy static assets completed +0ms
  statinamic:builder ✓ Static assets: client build completed +19s
  statinamic:static ✓ Static html files: 19 files written. +31s
  statinamic:static ✓ .nojekyll created. +20ms
  statinamic:static ✓ manifest.appcache created. +17ms
  statinamic:static ✓ Build successful. +0ms

real	0m57.426s
user	1m1.704s
sys	0m2.976s

```