### PR TITLE
Boilerplate: Production build now produces short CSS classnames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@
 
 - Changed: ``PageError`` is nicer and now looks like documentation 404.
 
+- Changed: Production build now produces short CSS classnames. You should apply this
+  change for a smaller HTML file.
+  ([#]())
+
 - Added: a ``PageLoading`` component is now provided and include 2 indicators:
   - A [topbar](https://github.com/buunguyen/topbar) via
     [react-topbar-progress-indicator](https://github.com/MoOx/react-topbar-progress-indicator).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@
 
 - Changed: Production build now produces short CSS classnames. You should apply this
   change for a smaller HTML file.
-  ([#]())
+  ([#385](https://github.com/MoOx/statinamic/pull/385))
 
 - Added: a ``PageLoading`` component is now provided and include 2 indicators:
   - A [topbar](https://github.com/buunguyen/topbar) via

--- a/boilerplate/scripts/webpack.config.babel.js
+++ b/boilerplate/scripts/webpack.config.babel.js
@@ -37,7 +37,12 @@ export default ({ config, pkg }) => ({
           "style-loader",
           "css-loader" + (
             "?modules"+
-            "&localIdentName=[path][name]--[local]--[hash:base64:5]"
+            "&localIdentName=" +
+            (
+              process.env.NODE_ENV === "production"
+              ? "[hash:base64:5]"
+              : "[path][name]--[local]--[hash:base64:5]"
+            ).toString()
           ) + "!" +
           "postcss-loader",
         ),

--- a/docs/scripts/webpack.config.babel.js
+++ b/docs/scripts/webpack.config.babel.js
@@ -37,7 +37,12 @@ export default ({ config, pkg }) => ({
           "style-loader",
           "css-loader" + (
             "?modules"+
-            "&localIdentName=[path][name]--[local]--[hash:base64:5]"
+            "&localIdentName=" +
+            (
+              process.env.NODE_ENV === "production"
+              ? "[hash:base64:5]"
+              : "[path][name]--[local]--[hash:base64:5]"
+            ).toString()
           ) + "!" +
           "postcss-loader",
         ),


### PR DESCRIPTION
Close #371